### PR TITLE
Fix bug where times = 0 would still result in a 💯

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -12,7 +12,13 @@ module.exports = function(eleventyConfig) {
 	});
 
 	eleventyConfig.addFilter("repeat", function(str, times) {
-		return (new Array(times)).join(str) + str;
+		let result = '';
+
+		for (let i = 0; i < times; i++) {
+			result += str;
+		}
+
+		return result;
 	});
 
 	eleventyConfig.addFilter("head", function(arr, num) {


### PR DESCRIPTION
Use a simple `for` loop instead of the original expression with an impromptu array, where `str` is always appended at least once, regardless of actual Lighthouse scores.