### PR TITLE
Add step with running tests to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ After you make a fast web site, keep it fast by measuring it over time.
 
 ```
 npm install
+npm run test-pages
 npm run start
 ```
 


### PR DESCRIPTION
Starting Eleventy on its own does not trigger tests and leaves user with an empty dashboard on first run. This change adds a test-pages step to local instructions to actually perform tests before opening dashboard.