### PR TITLE
Ignore results-last-run.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 .log
 _site
 _data/results/
+_data/results-last-run.json


### PR DESCRIPTION
Timestamp with last results was removed from code in 9a773cad03fe9a676451c6dcf0c2f2246a211dd3 in order to use the cached version. However, it's not gitignored and can result being accidental commited. This change adds results-last-run.json to gitignore in order to prevent this.