### PR TITLE
Allows adding a `frequency` (in minutes) to the options for each category

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -10,7 +10,7 @@
 	</head>
 	<body>
 		<h1 class="speedlify-hed">speedlify{% if vertical %}:{{ vertical }}{% endif %}</h1>
-		<p class="speedlify-subhed">Benchmark {{ sites[vertical].description or "web pages" }} over time (ordered by Lighthouse scores). Updates <em>at most</em> once an hour and automatically once a day. Only the last {{ maxResults }} result{% if maxResults != 1 %}s{% endif %} (and the oldest result) are shown. Read <a href="https://www.zachleat.com/web/speedlify/">the blog post</a>. Created by <a href="https://www.zachleat.com/">@zachleat</a>.</p>
+		<p class="speedlify-subhed">Benchmark {{ sites[vertical].description or "web pages" }} over time (ordered by Lighthouse scores). Updates <em>at most</em> once every {{ sites[vertical].options.frequency or 60 }} minutes and automatically once a day. Only the last {{ maxResults }} result{% if maxResults != 1 %}s{% endif %} (and the oldest result) are shown. Read <a href="https://www.zachleat.com/web/speedlify/">the blog post</a>. Created by <a href="https://www.zachleat.com/">@zachleat</a>.</p>
 
 		{{ content | safe }}
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -18,7 +18,7 @@ const FREQUENCY = 60;
 	}
 
 	let groups = require("./_data/sites.js");
-	for (let key in groups) {
+	for(let key in groups) {
 		let group = groups[key];
 		let runFrequency =
 			group.options && group.options.frequency
@@ -50,7 +50,7 @@ const FREQUENCY = 60;
 		);
 
 		let promises = [];
-		for (let result of results) {
+		for(let result of results) {
 			let id = shortHash(result.url);
 			let dir = `${dataDir}results/${id}/`;
 			let filename = `${dir}date-${today}.json`;
@@ -61,7 +61,7 @@ const FREQUENCY = 60;
 
 		await Promise.all(promises);
 		lastRuns[key] = { timestamp: today };
-		console.log(`Finished testing "${key}".`);
+		console.log( `Finished testing "${key}".` );
 	}
 
 	// Write the last run time to avoid re-runs

--- a/run-tests.js
+++ b/run-tests.js
@@ -6,64 +6,64 @@ const NUMBER_OF_RUNS = 3;
 const FREQUENCY = 60;
 
 (async function() {
-  let today = Date.now();
-  let dataDir = `./_data/`;
-  let lastRunsFilename = `${dataDir}results-last-run.json`;
-  let lastRuns;
-  try {
-    lastRuns = require(lastRunsFilename);
-  } catch (e) {
-    console.log(`There are no known last run timestamps`);
-    lastRuns = {};
-  }
+	let today = Date.now();
+	let dataDir = `./_data/`;
+	let lastRunsFilename = `${dataDir}results-last-run.json`;
+	let lastRuns;
+	try {
+		lastRuns = require(lastRunsFilename);
+	} catch (e) {
+		console.log(`There are no known last run timestamps`);
+		lastRuns = {};
+	}
 
-  let groups = require("./_data/sites.js");
-  for (let key in groups) {
-    let group = groups[key];
-    let runFrequency =
-      group.options && group.options.frequency
-        ? group.options.frequency
-        : FREQUENCY;
-    if (!lastRuns[key]) {
-      console.log(`First tests for ${key}.`);
-    } else {
-      const lastRun = lastRuns[key];
-      const lastRunMinutesAgo = (today - lastRun.timestamp) / (1000 * 60);
-      console.log(
-        `Tests for ${key} ran ${lastRunMinutesAgo} minutes ago.`,
-        lastRun
-      );
-      if (lastRunMinutesAgo < runFrequency) {
-        console.log(
-          `Test ran less than ${runFrequency} minutes ago, skipping.`
-        );
-        continue;
-      }
-    }
+	let groups = require("./_data/sites.js");
+	for (let key in groups) {
+		let group = groups[key];
+		let runFrequency =
+			group.options && group.options.frequency
+				? group.options.frequency
+				: FREQUENCY;
+		if (!lastRuns[key]) {
+			console.log(`First tests for ${key}.`);
+		} else {
+			const lastRun = lastRuns[key];
+			const lastRunMinutesAgo = (today - lastRun.timestamp) / (1000 * 60);
+			console.log(
+				`Tests for ${key} ran ${lastRunMinutesAgo} minutes ago.`,
+				lastRun
+			);
+			if (lastRunMinutesAgo < runFrequency) {
+				console.log(
+					`Test ran less than ${runFrequency} minutes ago, skipping.`
+				);
+				continue;
+			}
+		}
 
-    let runCount =
-      group.options && group.options.runs ? group.options.runs : NUMBER_OF_RUNS;
-    let results = await PerfLeaderboard(
-      group.urls,
-      runCount,
-      group.options || {}
-    );
+		let runCount =
+			group.options && group.options.runs ? group.options.runs : NUMBER_OF_RUNS;
+		let results = await PerfLeaderboard(
+			group.urls,
+			runCount,
+			group.options || {}
+		);
 
-    let promises = [];
-    for (let result of results) {
-      let id = shortHash(result.url);
-      let dir = `${dataDir}results/${id}/`;
-      let filename = `${dir}date-${today}.json`;
-      await fs.mkdir(dir, { recursive: true });
-      promises.push(fs.writeFile(filename, JSON.stringify(result, null, 2)));
-      console.log(`Writing ${filename}.`);
-    }
+		let promises = [];
+		for (let result of results) {
+			let id = shortHash(result.url);
+			let dir = `${dataDir}results/${id}/`;
+			let filename = `${dir}date-${today}.json`;
+			await fs.mkdir(dir, { recursive: true });
+			promises.push(fs.writeFile(filename, JSON.stringify(result, null, 2)));
+			console.log(`Writing ${filename}.`);
+		}
 
-    await Promise.all(promises);
-    lastRuns[key] = { timestamp: today };
-    console.log(`Finished testing "${key}".`);
-  }
+		await Promise.all(promises);
+		lastRuns[key] = { timestamp: today };
+		console.log(`Finished testing "${key}".`);
+	}
 
-  // Write the last run time to avoid re-runs
-  await fs.writeFile(lastRunsFilename, JSON.stringify(lastRuns, null, 2));
+	// Write the last run time to avoid re-runs
+	await fs.writeFile(lastRunsFilename, JSON.stringify(lastRuns, null, 2));
 })();

--- a/run-tests.js
+++ b/run-tests.js
@@ -56,7 +56,7 @@ const FREQUENCY = 60;
 			let filename = `${dir}date-${today}.json`;
 			await fs.mkdir(dir, { recursive: true });
 			promises.push(fs.writeFile(filename, JSON.stringify(result, null, 2)));
-			console.log(`Writing ${filename}.`);
+			console.log( `Writing ${filename}.` );
 		}
 
 		await Promise.all(promises);

--- a/run-tests.js
+++ b/run-tests.js
@@ -8,7 +8,7 @@ const FREQUENCY = 60;
 (async function() {
 	let today = Date.now();
 	let dataDir = `./_data/`;
-	let lastRunsFilename = `${dataDir}results-last-run.json`;
+	let lastRunsFilename = `${dataDir}results-last-runs.json`;
 	let lastRuns;
 	try {
 		lastRuns = require(lastRunsFilename);

--- a/run-tests.js
+++ b/run-tests.js
@@ -3,43 +3,67 @@ const shortHash = require("short-hash");
 const PerfLeaderboard = require("performance-leaderboard");
 
 const NUMBER_OF_RUNS = 3;
+const FREQUENCY = 60;
 
 (async function() {
-	let today = Date.now();
-	let dataDir = `./_data/`;
-	let lastRunFilename = `${dataDir}results-last-run.json`;
-	try {
-		const lastRun = require(lastRunFilename);
-		const lastRunHoursAgo = (today - lastRun.timestamp) / (1000*60*60);
-		console.log( `Tests ran ${lastRunHoursAgo} hours ago.`, lastRun );
-		if(lastRunHoursAgo < 1) {
-			console.log( "Test ran less than an hour ago, skipping." );
-			return;
-		}
-	} catch(e) {
-		console.log( `Error comparing ${lastRunFilename}`, e );
-	}
+  let today = Date.now();
+  let dataDir = `./_data/`;
+  let lastRunsFilename = `${dataDir}results-last-run.json`;
+  let lastRuns;
+  try {
+    lastRuns = require(lastRunsFilename);
+  } catch (e) {
+    console.log(`There are no known last run timestamps`);
+    lastRuns = {};
+  }
 
-	let groups = require("./_data/sites.js");
-	for(let key in groups) {
-		let group = groups[key];
-		let runCount = group.options && group.options.runs ? group.options.runs : NUMBER_OF_RUNS;
-		let results = await PerfLeaderboard(group.urls, runCount, group.options || {});
+  let groups = require("./_data/sites.js");
+  for (let key in groups) {
+    let group = groups[key];
+    let runFrequency =
+      group.options && group.options.frequency
+        ? group.options.frequency
+        : FREQUENCY;
+    if (!lastRuns[key]) {
+      console.log(`First tests for ${key}.`);
+    } else {
+      const lastRun = lastRuns[key];
+      const lastRunMinutesAgo = (today - lastRun.timestamp) / (1000 * 60);
+      console.log(
+        `Tests for ${key} ran ${lastRunMinutesAgo} minutes ago.`,
+        lastRun
+      );
+      if (lastRunMinutesAgo < runFrequency) {
+        console.log(
+          `Test ran less than ${runFrequency} minutes ago, skipping.`
+        );
+        continue;
+      }
+    }
 
-		let promises = [];
-		for(let result of results) {
-			let id = shortHash(result.url);
-			let dir = `${dataDir}results/${id}/`;
-			let filename = `${dir}date-${today}.json`;
-			await fs.mkdir(dir, { recursive: true });
-			promises.push(fs.writeFile(filename, JSON.stringify(result, null, 2)));
-			console.log( `Writing ${filename}.` );
-		}
+    let runCount =
+      group.options && group.options.runs ? group.options.runs : NUMBER_OF_RUNS;
+    let results = await PerfLeaderboard(
+      group.urls,
+      runCount,
+      group.options || {}
+    );
 
-		await Promise.all(promises);
-		console.log( `Finished testing "${key}".` );
-	}
+    let promises = [];
+    for (let result of results) {
+      let id = shortHash(result.url);
+      let dir = `${dataDir}results/${id}/`;
+      let filename = `${dir}date-${today}.json`;
+      await fs.mkdir(dir, { recursive: true });
+      promises.push(fs.writeFile(filename, JSON.stringify(result, null, 2)));
+      console.log(`Writing ${filename}.`);
+    }
 
-	// Write the last run time to avoid re-runs
-	await fs.writeFile(lastRunFilename, JSON.stringify({ timestamp: today }, null, 2));
+    await Promise.all(promises);
+    lastRuns[key] = { timestamp: today };
+    console.log(`Finished testing "${key}".`);
+  }
+
+  // Write the last run time to avoid re-runs
+  await fs.writeFile(lastRunsFilename, JSON.stringify(lastRuns, null, 2));
 })();


### PR DESCRIPTION
For example, if you wanted to run audits for your `netlify` category every 10 minutes, you can add this:

```json
module.exports = {
  netlify: {
    description: "Netlify web sites",
    options: {
      freshChrome: "site",
      frequency: 10,
    },
    urls: [
      "https://www.netlify.com/",
      "https://www.netlify.com/donation-matching/",
      "https://www.netlify.com/products/build/plugins/",
      "https://www.netlify.com/with/sitecore/",
      "https://www.netlify.com/with/drupal/",
      "https://www.netlify.com/with/wordpress/",
      "https://www.netlify.com/webinar/a-drupal-journey-to-the-jamstack/",
      "https://jamstackconf.com/",
      "https://jamstackconf.com/virtual/",
    ],
  },
}
```

Runs timestamps are save in the same file.

There is a 60 minutes default.