### PR TITLE
Add url filter to all links

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -5,13 +5,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Speedlify</title>
 		<meta name="description" content="Benchmark web pages over time.">
-		<link rel="stylesheet" href="/style.css">
+		<link rel="stylesheet" href="{{ '/style.css' | url }}">
 		<script>
 		document.documentElement.classList.add("js");
 		</script>
 	</head>
 	<body>
-		<h1 class="speedlify-hed"><a href="/">speedlify</a>{% if vertical %}:{{ vertical }}{% endif %}</h1>
+		<h1 class="speedlify-hed"><a href="{{ '/' | url }}">speedlify</a>{% if vertical %}:{{ vertical }}{% endif %}</h1>
 		<p class="speedlify-subhed">
 			Benchmark {{ sites[vertical].description or "web pages" }} over time.
 			{%- if maxResults %}
@@ -29,7 +29,7 @@
 			MIT licensed. Read <a href="https://www.zachleat.com/web/speedlify/">the blog post</a>. Source code on <a href="https://github.com/zachleat/speedlify/">GitHub</a>. Created by <a href="https://www.zachleat.com/">@zachleat</a>.
 		</footer>
 
-		<script defer src="/chartist.js"></script>
-		<script defer src="/script.js"></script>
+		<script defer src="{{ '/chartist.js' | url }}"></script>
+		<script defer src="{{ '/script.js' | url }}"></script>
 	</body>
 </html>

--- a/index.njk
+++ b/index.njk
@@ -39,7 +39,7 @@ layout: layout.njk
 	{%- for key, category in sites %}
 		{%- if not category.hide %}
 		<tr>
-			<td><a href="/{{ (category.name or key) | lower | slug }}/">{{ category.description or category.name or key }}</a></td>
+			<td><a href="{{ ('/' + (category.name or key) | lower | slug + '/') | url }}">{{ category.description or category.name or key }}">{{ category.description or category.name or key }}</a></td>
 			<td><span class="count">×{{ category.urls.length }}<span class="leaderboard-hide-sm"> site{% if category.urls.length != 1 %}s{% endif %}</span></span></td>
 			<td class="leaderboard-hide-sm">{% if lastruns[key].timestamp %}<span class="small"><timestamp-ago timestamp="{{ lastruns[key].timestamp }}">{{ lastruns[key].timestamp | displayDate | safe }}</timestamp-ago></span>{% endif %}</td>
 		</tr>

--- a/index.njk
+++ b/index.njk
@@ -39,7 +39,7 @@ layout: layout.njk
 	{%- for key, category in sites %}
 		{%- if not category.hide %}
 		<tr>
-			<td><a href="{{ ('/' + (category.name or key) | lower | slug + '/') | url }}">{{ category.description or category.name or key }}">{{ category.description or category.name or key }}</a></td>
+			<td><a href="{{ ('/' + (category.name or key) | lower | slug + '/') | url }}">{{ category.description or category.name or key }}</a></td>
 			<td><span class="count">×{{ category.urls.length }}<span class="leaderboard-hide-sm"> site{% if category.urls.length != 1 %}s{% endif %}</span></span></td>
 			<td class="leaderboard-hide-sm">{% if lastruns[key].timestamp %}<span class="small"><timestamp-ago timestamp="{{ lastruns[key].timestamp }}">{{ lastruns[key].timestamp | displayDate | safe }}</timestamp-ago></span>{% endif %}</td>
 		</tr>


### PR DESCRIPTION
In order to support `pathPrefix` configuration and be able to deploy to GitHub Pages, all internal links should pass through the `url` filter.