### PR TITLE
feature: allow sites to be disabled through file naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ After you make a fast web site, keep it fast by measuring it over time. Read [Us
 
 * Requires Node 12+
 * Each file in `_data/sites/*.js` is a category and contains a list of sites for comparison.
+  * A site file can be disabled by ending its filename with `.disabled.js`.
 
 ## Run locally
 

--- a/_data/isolatedKeys.js
+++ b/_data/isolatedKeys.js
@@ -2,7 +2,7 @@ const shortHash = require("short-hash");
 const fastglob = require("fast-glob");
 
 module.exports = async function() {
-	let categories = await fastglob("./_data/sites/*.js", {
+	let categories = await fastglob(["./_data/sites/*.js", "!/_data/sites/*.disabled.js"], {
 		caseSensitiveMatch: false
 	});
 

--- a/_data/isolatedKeys.js
+++ b/_data/isolatedKeys.js
@@ -2,7 +2,7 @@ const shortHash = require("short-hash");
 const fastglob = require("fast-glob");
 
 module.exports = async function() {
-	let categories = await fastglob(["./_data/sites/*.js", "!/_data/sites/*.disabled.js"], {
+	let categories = await fastglob("./_data/sites/!(*.disabled)*.js", {
 		caseSensitiveMatch: false
 	});
 

--- a/_data/sites/sample.disabled.js
+++ b/_data/sites/sample.disabled.js
@@ -1,7 +1,7 @@
 // If you need to disable a site, rename it to end in `.disabled.js`
 module.exports = {
-	name: "Sample", // optional, falls back to object key
-	description: "The default sites that get tested",
+	name: "Sample disabled test", // optional, falls back to object key
+	description: "This test will not run",
 	options: {
 		frequency: 60 * 23, // (in minutes), 23 hours
 	},

--- a/_data/sites/sample.disabled.js
+++ b/_data/sites/sample.disabled.js
@@ -1,0 +1,11 @@
+// If you need to disable a site, rename it to end in `.disabled.js`
+module.exports = {
+	name: "Sample", // optional, falls back to object key
+	description: "The default sites that get tested",
+	options: {
+		frequency: 60 * 23, // (in minutes), 23 hours
+	},
+	urls: [
+		"https://www.speedlify.dev/"
+	]
+};

--- a/_data/urlsForApi.js
+++ b/_data/urlsForApi.js
@@ -1,7 +1,7 @@
 const fastglob = require("fast-glob");
 
 async function getCategoryToUrlMap() {
-	let categories = await fastglob(["./_data/sites/*.js", "!/_data/sites/*.disabled.js"], {
+	let categories = await fastglob("./_data/sites/!(*.disabled)*.js", {
 		caseSensitiveMatch: false
 	});
 

--- a/_data/urlsForApi.js
+++ b/_data/urlsForApi.js
@@ -1,7 +1,7 @@
 const fastglob = require("fast-glob");
 
 async function getCategoryToUrlMap() {
-	let categories = await fastglob("./_data/sites/*.js", {
+	let categories = await fastglob(["./_data/sites/*.js", "!/_data/sites/*.disabled.js"], {
 		caseSensitiveMatch: false
 	});
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -59,7 +59,7 @@ async function tryToPreventNetlifyBuildTimeout(dateTestsStarted, numberOfUrls, e
 		lastRuns = {};
 	}
 
-	let verticals = await fastglob(["./_data/sites/*.js", "!/_data/sites/*.disabled.js"], {
+	let verticals = await fastglob("./_data/sites/!(*.disabled)*.js", {
 		caseSensitiveMatch: false
 	});
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -59,7 +59,7 @@ async function tryToPreventNetlifyBuildTimeout(dateTestsStarted, numberOfUrls, e
 		lastRuns = {};
 	}
 
-	let verticals = await fastglob("./_data/sites/*.js", {
+	let verticals = await fastglob(["./_data/sites/*.js", "!/_data/sites/*.disabled.js"], {
 		caseSensitiveMatch: false
 	});
 


### PR DESCRIPTION
A small change that allows a site file configuration to be disabled by ending it with `.disabled.js`.

I've found this easier/preferable to temporarily deleting the file.

Another approach would be to add a `enabled: true/false` property, but this was simpler to implement -- and I think  it's more obvious if a site is disabled.

Maybe you'll like the idea.

## Update

I've now seen it's possible to add a `	skip: true`  parameter.

I think that makes this PR not required -- however I think this could have been more obvious, open to a PR adding that to the readme?