### PR TITLE
Add Lighthouse & page weight sparklines

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -354,7 +354,7 @@ module.exports = function(eleventyConfig) {
     );
     const values = timeSeries.map((run) => run.weight.total);
     return Sparkline({
-      color: '#915ffc',
+      color: '#d151ff',
       values,
       min: 0,
       timeSeries,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -326,44 +326,44 @@ module.exports = function(eleventyConfig) {
 		ui: false,
 		ghostMode: false
 	});
-  eleventyConfig.addShortcode('lighthouseSparkline', (site) => {
-    const timeSeries = Object.values(site).sort(
-      (a, b) => a.timestamp - b.timestamp
-    );
-    const values = timeSeries.map((run) => run.lighthouse.total);
-    return Sparkline({
-      // red-orange-green gradient similar to usage in <speedlify-score>
-      gradient: [
-        { color: '#ff4e42', offset: '0%' },
-        { color: '#ff4e42', offset: '30%' },
-        { color: '#ffa400', offset: '70%' },
-        { color: '#ffa400', offset: '85%' },
-        { color: '#0cce6b', offset: '95%' },
-        { color: '#0cce6b', offset: '100%' },
-      ],
-      values,
-      min: 0,
-      max: 400,
-      timeSeries,
-    });
-  });
+	eleventyConfig.addShortcode('lighthouseSparkline', (site) => {
+		const timeSeries = Object.values(site).sort(
+			(a, b) => a.timestamp - b.timestamp
+		);
+		const values = timeSeries.map((run) => run.lighthouse.total);
+		return Sparkline({
+			// red-orange-green gradient similar to usage in <speedlify-score>
+			gradient: [
+				{ color: '#ff4e42', offset: '0%' },
+				{ color: '#ff4e42', offset: '30%' },
+				{ color: '#ffa400', offset: '70%' },
+				{ color: '#ffa400', offset: '85%' },
+				{ color: '#0cce6b', offset: '95%' },
+				{ color: '#0cce6b', offset: '100%' },
+			],
+			values,
+			min: 0,
+			max: 400,
+			timeSeries,
+		});
+	});
 
-  eleventyConfig.addShortcode('weightSparkline', (site) => {
-    const timeSeries = Object.values(site).sort(
-      (a, b) => a.timestamp - b.timestamp
-    );
-    const values = timeSeries.map((run) => run.weight.total);
-    return Sparkline({
-      color: '#d151ff',
-      values,
-      min: 0,
-      timeSeries,
+	eleventyConfig.addShortcode('weightSparkline', (site) => {
+		const timeSeries = Object.values(site).sort(
+			(a, b) => a.timestamp - b.timestamp
+		);
+		const values = timeSeries.map((run) => run.weight.total);
+		return Sparkline({
+			color: '#d151ff',
+			values,
+			min: 0,
+			timeSeries,
 			// Display raw bytes as pretty values on y axis, e.g. 49244 => 48K
-      formatAxis: (num) => {
-        const { value, unit } = byteSize(num, { units: 'iec', precision: 0 });
-        return value === '0' ? value : value + unit.slice(0, 1);
-      },
-    });
-  });
+			formatAxis: (num) => {
+				const { value, unit } = byteSize(num, { units: 'iec', precision: 0 });
+				return value === '0' ? value : value + unit.slice(0, 1);
+			},
+		});
+	});
 
 };

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -358,6 +358,7 @@ module.exports = function(eleventyConfig) {
       values,
       min: 0,
       timeSeries,
+			// Display raw bytes as pretty values on y axis, e.g. 49244 => 48K
       formatAxis: (num) => {
         const { value, unit } = byteSize(num, { units: 'iec', precision: 0 });
         return value === '0' ? value : value + unit.slice(0, 1);

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,6 +3,7 @@ const shortHash = require("short-hash");
 const lodash = require("lodash");
 const getObjectKey = require("./utils/getObjectKey.js");
 const calc = require("./utils/calc.js");
+const Sparkline = require('./utils/sparkline.js');
 
 function hasUrl(urls, requestedUrl) {
 	// urls comes from sites[vertical].urls, all requestedUrls (may not include trailing slash)
@@ -325,4 +326,43 @@ module.exports = function(eleventyConfig) {
 		ui: false,
 		ghostMode: false
 	});
+  eleventyConfig.addShortcode('lighthouseSparkline', (site) => {
+    const timeSeries = Object.values(site).sort(
+      (a, b) => a.timestamp - b.timestamp
+    );
+    const values = timeSeries.map((run) => run.lighthouse.total);
+    return Sparkline({
+      // red-orange-green gradient similar to usage in <speedlify-score>
+      gradient: [
+        { color: '#ff4e42', offset: '0%' },
+        { color: '#ff4e42', offset: '30%' },
+        { color: '#ffa400', offset: '70%' },
+        { color: '#ffa400', offset: '85%' },
+        { color: '#0cce6b', offset: '95%' },
+        { color: '#0cce6b', offset: '100%' },
+      ],
+      values,
+      min: 0,
+      max: 400,
+      timeSeries,
+    });
+  });
+
+  eleventyConfig.addShortcode('weightSparkline', (site) => {
+    const timeSeries = Object.values(site).sort(
+      (a, b) => a.timestamp - b.timestamp
+    );
+    const values = timeSeries.map((run) => run.weight.total);
+    return Sparkline({
+      color: '#915ffc',
+      values,
+      min: 0,
+      timeSeries,
+      formatAxis: (num) => {
+        const { value, unit } = byteSize(num, { units: 'iec', precision: 0 });
+        return value === '0' ? value : value + unit.slice(0, 1);
+      },
+    });
+  });
+
 };

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -352,7 +352,7 @@ module.exports = function(eleventyConfig) {
 		const timeSeries = Object.values(site).sort(
 			(a, b) => a.timestamp - b.timestamp
 		);
-		const values = timeSeries.map((run) => run.weight.total);
+		const values = timeSeries.map((run) => run.weight?.total || 0);
 		return Sparkline({
 			color: '#d151ff',
 			values,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -330,7 +330,7 @@ module.exports = function(eleventyConfig) {
 		const timeSeries = Object.values(site).sort(
 			(a, b) => a.timestamp - b.timestamp
 		);
-		const values = timeSeries.map((run) => run.lighthouse.total);
+		const values = timeSeries.map((run) => run.lighthouse?.total || 0);
 		return Sparkline({
 			// red-orange-green gradient similar to usage in <speedlify-score>
 			gradient: [

--- a/assets/css.njk
+++ b/assets/css.njk
@@ -4,3 +4,4 @@ permalink: style.css
 {% include "../node_modules/chartist/dist/chartist.css" %}
 {% include "../node_modules/speedlify-score/speedlify-score.css" %}
 {% include "./style.css" %}
+{% include "./sparkline.css" %}

--- a/assets/sparkline.css
+++ b/assets/sparkline.css
@@ -1,0 +1,31 @@
+.sparkline {
+  vertical-align: middle;
+  display: inline-grid;
+  grid-template: auto auto / auto auto;
+  gap: 0.25rem;
+}
+.sparkline .x-axis,
+.sparkline .y-axis {
+  display: flex;
+  justify-content: space-between;
+  line-height: 0.65;
+  font-size: 0.5rem;
+  color: hsl(0, 0%, 50%);
+}
+.sparkline .y-axis {
+  flex-direction: column-reverse;
+  text-align: right;
+}
+.sparkline .x-axis {
+  grid-column: 2 / 3;
+}
+.sparkline svg {
+  --white: 255, 0%, 100%;
+  background: linear-gradient(hsla(var(--white), 0.1), transparent);
+  border-left: 1px solid hsla(var(--white), 0.1);
+  border-bottom: 1px solid hsla(var(--white), 0.1);
+  width: 4.375rem;
+  height: 100%;
+  stroke-width: 1.5px;
+  stroke-linejoin: round;
+}

--- a/assets/sparkline.css
+++ b/assets/sparkline.css
@@ -1,31 +1,31 @@
 .sparkline {
-  vertical-align: middle;
-  display: inline-grid;
-  grid-template: auto auto / auto auto;
-  gap: 0.25rem;
+	vertical-align: middle;
+	display: inline-grid;
+	grid-template: auto auto / auto auto;
+	gap: 0.25rem;
 }
 .sparkline .x-axis,
 .sparkline .y-axis {
-  display: flex;
-  justify-content: space-between;
-  line-height: 0.65;
-  font-size: 0.5rem;
-  color: hsl(0, 0%, 50%);
+	display: flex;
+	justify-content: space-between;
+	line-height: 0.65;
+	font-size: 0.5rem;
+	color: hsl(0, 0%, 50%);
 }
 .sparkline .y-axis {
-  flex-direction: column-reverse;
-  text-align: right;
+	flex-direction: column-reverse;
+	text-align: right;
 }
 .sparkline .x-axis {
-  grid-column: 2 / 3;
+	grid-column: 2 / 3;
 }
 .sparkline svg {
-  --white: 255, 0%, 100%;
-  background: linear-gradient(hsla(var(--white), 0.1), transparent);
-  border-left: 1px solid hsla(var(--white), 0.1);
-  border-bottom: 1px solid hsla(var(--white), 0.1);
-  width: 4.375rem;
-  height: 100%;
-  stroke-width: 1.5px;
-  stroke-linejoin: round;
+	--white: 255, 0%, 100%;
+	background: linear-gradient(hsla(var(--white), 0.1), transparent);
+	border-left: 1px solid hsla(var(--white), 0.1);
+	border-bottom: 1px solid hsla(var(--white), 0.1);
+	width: 4.375rem;
+	height: 100%;
+	stroke-width: 1.5px;
+	stroke-linejoin: round;
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -47,7 +47,7 @@ summary {
 	word-break: break-all;
 	word-break: break-word;
 }
-@media (min-width: 37.5em) { /* 600px */
+@media (min-width: 60em) { /* 960px */
 	.url {
 		font-size: 1.25em; /* 20px /16 */
 	}
@@ -214,7 +214,7 @@ abbr {
 		display: none;
 	}
 }
-@media (max-width: 63.9375em) { /* 1023px */
+@media (max-width: 72em) { /* 1152px */
 	.leaderboard-hide-md {
 		display: none;
 	}
@@ -351,12 +351,12 @@ abbr {
 .leaderboard-score{
 	white-space: nowrap;
 }
-@media (max-width: 28.0625em) { /* 449px */
+@media (max-width: 30em) { /* 480px */
 	.leaderboard-score{
 		display: none;
 	}
 }
-@media (max-width: 37.4375em) { /* 599px */
+@media (max-width: 60em) { /* 599px */
 	.leaderboard-score-circles {
 		display: none;
 	}

--- a/assets/style.css
+++ b/assets/style.css
@@ -356,7 +356,7 @@ abbr {
 		display: none;
 	}
 }
-@media (max-width: 60em) { /* 599px */
+@media (max-width: 60em) { /* 960px */
 	.leaderboard-score-circles {
 		display: none;
 	}

--- a/categories.njk
+++ b/categories.njk
@@ -25,6 +25,7 @@ counts:
 				<th>URL</th>
 				<th class="leaderboard-hide-md">Built With</th>
 				<th class="leaderboard-score">Lighthouse</th>
+				<th class="leaderboard-hide-sm">Page weight</th>
 				<th class="leaderboard-data-right"><span data-sr-only>Data and Graphs</span></th>
 			</tr>
 		</thead>
@@ -65,7 +66,8 @@ counts:
 				<td colspan="2"></td>
 			{%- else %}
 				{%- set counts = counts | hundoCountTotals(site[newestKey]) %}
-				<td class="leaderboard-score">{% if showRank %}<is-land on:visible><speedlify-score class="leaderboard-score-circles{% if hundos === 4 %} leaderboard-score-circles-400{% endif %}" raw-data='{{ site[newestKey] | toJSON | safe }}'></speedlify-score></is-land><span class="leaderboard-score-sum leaderboard-number">{% if hundos === 4 %}😍{% else %}{{ site[newestKey] | lighthouseTotal }}{% endif %}</span>{% endif %}</td>
+				<td class="leaderboard-score">{% if showRank %}<is-land on:visible><speedlify-score class="leaderboard-score-circles{% if hundos === 4 %} leaderboard-score-circles-400{% endif %}" raw-data='{{ site[newestKey] | toJSON | safe }}'></speedlify-score></is-land><span class="leaderboard-score-sum leaderboard-number">{% if hundos === 4 %}😍{% else %}{{ site[newestKey] | lighthouseTotal }}{% endif %}</span>{% endif %}{% lighthouseSparkline site %}</td>
+				<td class="leaderboard-hide-sm">{% weightSparkline site %}</td>
 				<td class="leaderboard-data-right"><a href="#details-{{ site[key].url | shortHash }}" data-expand-alias data-js-only><span class="leaderboard-expand-icon"></span> Data<span class="leaderboard-hide-md"> and Graphs</span></a></td>
 			{%- endif %}
 			</tr>

--- a/utils/sparkline.js
+++ b/utils/sparkline.js
@@ -99,6 +99,8 @@ function Sparkline({
 
 	const minVal = Math.min(...values);
 	const maxVal = Math.max(...values);
+	const caption = `Sparkline ranging between ${formatAxis(minVal)} and ${formatAxis(maxVal)}.`;
+
 	const data = values.map((val) => Math.max(0, Math.round(val) - min));
 	const maxY = Math.max(...data, max - min);
 	const [width, height] = [70, 40];
@@ -119,9 +121,7 @@ function Sparkline({
 		preserveAspectRatio="none"
 		viewBox="0 0 ${width} ${height}"
 	>
-		<title>
-			Sparkline ranging between ${formatAxis(minVal)} and ${formatAxis(maxVal)}.
-		</title>
+		<title>${caption}</title>
 		<path
 			fill="transparent"
 			stroke="${gradient ? `url(#${id})` : color}" d="${d}"

--- a/utils/sparkline.js
+++ b/utils/sparkline.js
@@ -1,5 +1,5 @@
 function uuid() {
-  return Math.round(Math.random() * 10e9).toString(36);
+	return Math.round(Math.random() * 10e9).toString(36);
 }
 
 /**
@@ -8,8 +8,8 @@ function uuid() {
  * @returns {string}
  */
 function msToDate(timestamp) {
-  const date = new Date(timestamp);
-  return date.toLocaleDateString(['en-US'], { day: 'numeric', month: 'short' });
+	const date = new Date(timestamp);
+	return date.toLocaleDateString(['en-US'], { day: 'numeric', month: 'short' });
 }
 
 /**
@@ -18,8 +18,8 @@ function msToDate(timestamp) {
  * @returns {string}
  */
 function msToISO(timestamp) {
-  const date = new Date(timestamp);
-  return date.toISOString();
+	const date = new Date(timestamp);
+	return date.toISOString();
 }
 
 /**
@@ -29,8 +29,8 @@ function msToISO(timestamp) {
  * @returns {number} Rounded number
  */
 function round(n, decimals = 1) {
-  const power = 10 ** decimals;
-  return Math.round(n * power) / power;
+	const power = 10 ** decimals;
+	return Math.round(n * power) / power;
 }
 
 /**
@@ -42,13 +42,13 @@ function round(n, decimals = 1) {
  * @returns {string}
  */
 function getD(data, w, h, maxY) {
-  /** @type {string[]} */
-  let l = [];
-  const maxX = data.length - 1;
-  for (let i = 0; i <= maxX; i++) {
-    l.push(round((i / maxX) * w) + ',' + round(h - (data[i] / maxY) * h));
-  }
-  return `M ${l.join(' L ')}`;
+	/** @type {string[]} */
+	let l = [];
+	const maxX = data.length - 1;
+	for (let i = 0; i <= maxX; i++) {
+		l.push(round((i / maxX) * w) + ',' + round(h - (data[i] / maxY) * h));
+	}
+	return `M ${l.join(' L ')}`;
 }
 
 /**
@@ -58,15 +58,15 @@ function getD(data, w, h, maxY) {
  * @returns {string}
  */
 function getLinearGradient(gradient, id) {
-  const stops = gradient
-    .map((s) => `<stop stop-color="${s.color}" offset="${s.offset}" />`)
-    .join('');
+	const stops = gradient
+		.map((s) => `<stop stop-color="${s.color}" offset="${s.offset}" />`)
+		.join('');
 
-  return (
-    `<linearGradient id="${id}" x1="0" x2="0" y1="100%" y2="0" gradientUnits="userSpaceOnUse">` +
-    stops +
-    `</linearGradient>`
-  );
+	return (
+		`<linearGradient id="${id}" x1="0" x2="0" y1="100%" y2="0" gradientUnits="userSpaceOnUse">` +
+		stops +
+		`</linearGradient>`
+	);
 }
 
 /**
@@ -86,57 +86,57 @@ function getLinearGradient(gradient, id) {
  * @return {string}
  */
 function Sparkline({
-  values,
-  min = Math.min(...values),
-  max = Math.max(...values),
-  color = '#ffffff',
-  gradient,
-  formatAxis = (val) => val,
-  timeSeries,
+	values,
+	min = Math.min(...values),
+	max = Math.max(...values),
+	color = '#ffffff',
+	gradient,
+	formatAxis = (val) => val,
+	timeSeries,
 }) {
-  // If we only have one data point, duplicate it to draw a straight line.
-  if (values.length === 1) values.push(...values);
+	// If we only have one data point, duplicate it to draw a straight line.
+	if (values.length === 1) values.push(...values);
 
-  const minVal = Math.min(...values);
-  const maxVal = Math.max(...values);
-  const data = values.map((val) => Math.max(0, Math.round(val) - min));
-  const maxY = Math.max(...data, max - min);
-  const [width, height] = [70, 40];
+	const minVal = Math.min(...values);
+	const maxVal = Math.max(...values);
+	const data = values.map((val) => Math.max(0, Math.round(val) - min));
+	const maxY = Math.max(...data, max - min);
+	const [width, height] = [70, 40];
 
-  const startTime = timeSeries?.at(0)?.timestamp;
-  const endTime = timeSeries?.at(-1)?.timestamp;
+	const startTime = timeSeries?.at(0)?.timestamp;
+	const endTime = timeSeries?.at(-1)?.timestamp;
 
-  const d = getD(data, width, height, maxY);
-  const id = uuid();
+	const d = getD(data, width, height, maxY);
+	const id = uuid();
 
-  return `<div class="sparkline">
-  <div class="y-axis" aria-hidden="true">
-    <div>${formatAxis(min)}</div>
-    <div>${formatAxis(max)}</div>
-  </div>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    preserveAspectRatio="none"
-    viewBox="0 0 ${width} ${height}"
-  >
-    <title>
-      Sparkline ranging between ${formatAxis(minVal)} and ${formatAxis(maxVal)}.
-    </title>
-    <path
-      fill="transparent"
-      stroke="${gradient ? `url(#${id})` : color}" d="${d}"
-    />
-    ${gradient ? getLinearGradient(gradient, id) : ''}
-  </svg>
-  ${
-    startTime && endTime
-      ? `
-  <div class="x-axis">
-    <time datetime="${msToISO(startTime)}">${msToDate(startTime)}</time>
-    <time datetime="${msToISO(startTime)}">${msToDate(endTime)}</time>
-  </div>`
-      : ''
-  }
+	return `<div class="sparkline">
+	<div class="y-axis" aria-hidden="true">
+		<div>${formatAxis(min)}</div>
+		<div>${formatAxis(max)}</div>
+	</div>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		preserveAspectRatio="none"
+		viewBox="0 0 ${width} ${height}"
+	>
+		<title>
+			Sparkline ranging between ${formatAxis(minVal)} and ${formatAxis(maxVal)}.
+		</title>
+		<path
+			fill="transparent"
+			stroke="${gradient ? `url(#${id})` : color}" d="${d}"
+		/>
+		${gradient ? getLinearGradient(gradient, id) : ''}
+	</svg>
+	${
+		startTime && endTime
+			? `
+	<div class="x-axis">
+		<time datetime="${msToISO(startTime)}">${msToDate(startTime)}</time>
+		<time datetime="${msToISO(startTime)}">${msToDate(endTime)}</time>
+	</div>`
+			: ''
+	}
 </div>`;
 }
 

--- a/utils/sparkline.js
+++ b/utils/sparkline.js
@@ -1,0 +1,143 @@
+function uuid() {
+  return Math.round(Math.random() * 10e9).toString(36);
+}
+
+/**
+ * Convert a timestamp in milliseconds to a month & date string, e.g. `Mar 31`.
+ * @param {number} timestamp Millisecond UNIX epoch timestamp
+ * @returns {string}
+ */
+function msToDate(timestamp) {
+  const date = new Date(timestamp);
+  return date.toLocaleDateString(['en-US'], { day: 'numeric', month: 'short' });
+}
+
+/**
+ * Convert a timestamp in milliseconds to an ISO format date string.
+ * @param {number} timestamp Millisecond UNIX epoch timestamp
+ * @returns {string}
+ */
+function msToISO(timestamp) {
+  const date = new Date(timestamp);
+  return date.toISOString();
+}
+
+/**
+ * Round a number to an arbitrary precision.
+ * @param {number} n Number to round
+ * @param {number} decimals Number of decimals to round to
+ * @returns {number} Rounded number
+ */
+function round(n, decimals = 1) {
+  const power = 10 ** decimals;
+  return Math.round(n * power) / power;
+}
+
+/**
+ * Get the `d` attribute for an SVG path representing a sparkline.
+ * @param {number[]} data
+ * @param {number} w
+ * @param {number} h
+ * @param {number} maxY
+ * @returns {string}
+ */
+function getD(data, w, h, maxY) {
+  /** @type {string[]} */
+  let l = [];
+  const maxX = data.length - 1;
+  for (let i = 0; i <= maxX; i++) {
+    l.push(round((i / maxX) * w) + ',' + round(h - (data[i] / maxY) * h));
+  }
+  return `M ${l.join(' L ')}`;
+}
+
+/**
+ * Get an SVG `<linearGradient>` definition.
+ * @param {{ color: string; offset: `${number}%`}[]} gradient - Color stops
+ * @param {string} id - Random ID used to associate gradient with stroke/fill.
+ * @returns {string}
+ */
+function getLinearGradient(gradient, id) {
+  const stops = gradient
+    .map((s) => `<stop stop-color="${s.color}" offset="${s.offset}" />`)
+    .join('');
+
+  return (
+    `<linearGradient id="${id}" x1="0" x2="0" y1="100%" y2="0" gradientUnits="userSpaceOnUse">` +
+    stops +
+    `</linearGradient>`
+  );
+}
+
+/**
+ * @typedef {Object} SparklineOptions
+ * @property {number[]} values - Array of values along the y axis to draw.
+ * @property {number} [min] - Minimum value on the y axis (defaults to smallest value in `values`).
+ * @property {number} [max] - Maximum value on the y axis (defaults to largest value in `values`).
+ * @property {string} [color] - Color to draw the sparkline with (defaults to white). Overridden if `gradient` is set.
+ * @property {{ color: string; offset: `${number}%` }[]} [gradient] - Gradient definition to draw the sparkline with.
+ * @property {(val: number) => string | number} [formatAxis] - Formatter for y-axis legend.
+ * @property {{ timestamp: number }[]} [timeSeries] - Sorted array of `performance-leaderboard` runs to extract timestamps from.
+ */
+
+/**
+ * Generate HTML for a sparkline.
+ * @param {SparklineOptions} opts
+ * @return {string}
+ */
+function Sparkline({
+  values,
+  min = Math.min(...values),
+  max = Math.max(...values),
+  color = '#ffffff',
+  gradient,
+  formatAxis = (val) => val,
+  timeSeries,
+}) {
+  // If we only have one data point, duplicate it to draw a straight line.
+  if (values.length === 1) values.push(...values);
+
+  const minVal = Math.min(...values);
+  const maxVal = Math.max(...values);
+  const data = values.map((val) => Math.max(0, Math.round(val) - min));
+  const maxY = Math.max(...data, max - min);
+  const [width, height] = [70, 40];
+
+  const startTime = timeSeries?.at(0)?.timestamp;
+  const endTime = timeSeries?.at(-1)?.timestamp;
+
+  const d = getD(data, width, height, maxY);
+  const id = uuid();
+
+  return `<div class="sparkline">
+  <div class="y-axis" aria-hidden="true">
+    <div>${formatAxis(min)}</div>
+    <div>${formatAxis(max)}</div>
+  </div>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    preserveAspectRatio="none"
+    viewBox="0 0 ${width} ${height}"
+  >
+    <title>
+      Sparkline ranging between ${formatAxis(minVal)} and ${formatAxis(maxVal)}.
+    </title>
+    <path
+      fill="transparent"
+      stroke="${gradient ? `url(#${id})` : color}" d="${d}"
+    />
+    ${gradient ? getLinearGradient(gradient, id) : ''}
+  </svg>
+  ${
+    startTime && endTime
+      ? `
+  <div class="x-axis">
+    <time datetime="${msToISO(startTime)}">${msToDate(startTime)}</time>
+    <time datetime="${msToISO(startTime)}">${msToDate(endTime)}</time>
+  </div>`
+      : ''
+  }
+</div>`;
+}
+
+module.exports = Sparkline;


### PR DESCRIPTION
This PR adds an SVG sparkline utility and `{% lighthouseSparkline site %}` and `{% weightSparkline site %}` shortcodes for showing small summaries of site data over time. I’ve added these to the main site overview:

<img width="1189" alt="Preview of new sparkline in Speedlify" src="https://user-images.githubusercontent.com/357379/223103279-55c0f869-f96d-4d54-8dfe-3e16294820eb.png">

I tweaked some of the breakpoints at which different stats get hidden to keep things working with these new elements. The importance of the different stats is a bit subjective, so I hope I prioritised things in an acceptable way.

The Lighthouse sparkline uses a colour scheme much like the speedlify score circles:
 
<img width="104" alt="Sparkline showing transitions of colour between red for low values, orange for mid range, and green for high values" src="https://user-images.githubusercontent.com/357379/223104276-82361fb6-fda9-48c6-b397-8b5cb440127a.png">

In my usage for Astro, I actually cropped this to the 360–400 range on the basis that any lower than that is too bad for variation to be interesting. Given the more generic usage here, I’ve left the Lighthouse sparkline showing 0–400. Easy enough to tweak in the shortcode function if you want to see variation in the upper range more clearly.

Let me know what you think and if you’d like any changes.